### PR TITLE
Comments out SSL/Let’s Encrypt config from ingress rules

### DIFF
--- a/cluster-components/cluster1/kuberos/ingress.yml
+++ b/cluster-components/cluster1/kuberos/ingress.yml
@@ -4,18 +4,18 @@ metadata:
   name: kuberos
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    kubernetes.io/tls-acme: "true"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    # kubernetes.io/tls-acme: "true"
+    # nginx.ingress.kubernetes.io/ssl-redirect: "true"
 spec:
   rules:
-  - host: kuberos.apps.cluster1.kops.integration.dsd.io
+  - host: login.apps.cluster1.kops.integration.dsd.io
     http:
       paths:
       - path: /
         backend:
           serviceName: kuberos
           servicePort: http
-  tls:
-  - secretName: kuberos-tls
-    hosts:
-    - "kuberos.apps.cluster1.kops.integration.dsd.io"
+  # tls:
+  # - secretName: kuberos-tls
+  #   hosts:
+  #   - "kuberos.apps.cluster1.kops.integration.dsd.io"

--- a/example-apps/nginx/ingress.yml
+++ b/example-apps/nginx/ingress.yml
@@ -4,18 +4,18 @@ metadata:
   name: example-nginx
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    kubernetes.io/tls-acme: "true"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    # kubernetes.io/tls-acme: "true"
+    # nginx.ingress.kubernetes.io/ssl-redirect: "true"
 spec:
   rules:
-  - host: example-nginx.apps.cluster1.kops.integration.dsd.io
+  - host: nginx-example.apps.cluster1.kops.integration.dsd.io
     http:
       paths:
       - path: /
         backend:
           serviceName: example-nginx
           servicePort: 80
-  tls:
-  - secretName: example-nginx-tls
-    hosts:
-    - "example-nginx.apps.cluster1.kops.integration.dsd.io"
+  # tls:
+  # - secretName: example-nginx-tls
+  #   hosts:
+  #   - "example-nginx.apps.cluster1.kops.integration.dsd.io"


### PR DESCRIPTION
As we’ve hit the Let’s Encrypt rate limit we’re unable to provision new certificates. We’re also unable to change to Let’s Encrypt staging API with self-signed certs, because nginx-ingress was using HSTS by default. So for now we’re removing SSL from ingress rules